### PR TITLE
add mentor others tab, compiler working groups

### DIFF
--- a/data/categories.json
+++ b/data/categories.json
@@ -222,5 +222,80 @@
     "labels": ["WG-infra-crates.io"],
     "links": [{ "text": "about", "url": "https://paper.dropbox.com/doc/Crates.io-g8NWnnNIeTq8DaqjGoZLr"}, {"text": "contributing", "url": "https://github.com/rust-lang/crates.io/blob/master/docs/CONTRIBUTING.md"}],
     "tags": ["crates-io", "lang-rust", "lang-JavaScript"]
+},
+{
+    "id": "compiler-errors",
+    "title": "compiler (error messages)",
+    "description": "The Rust compiler",
+    "repository": "rust-lang/rust",
+    "labels": ["WG-compiler-errors"],
+    "links": [{
+      "text": "about",
+      "url": "https://paper.dropbox.com/doc/Compiler-errors-FSZdfXAGo3uMQ1wuDcZcy"
+    }],
+    "tags": ["compiler", "lang-rust"]
+},
+{
+    "id": "compiler-front",
+    "title": "compiler (parser and name resolution)",
+    "description": "The Rust compiler",
+    "repository": "rust-lang/rust",
+    "labels": ["WG-compiler-front"],
+    "links": [],
+    "tags": ["compiler", "lang-rust"]
+},
+{
+    "id": "compiler-middle",
+    "title": "compiler (type checker)",
+    "description": "The Rust compiler",
+    "repository": "rust-lang/rust",
+    "labels": ["WG-compiler-middle"],
+    "links": [{
+      "text": "about",
+      "url": "https://paper.dropbox.com/doc/Middle-Type-checker-and-MIR-generation-XEPTHIWvzlvqkSC3cluTr"
+    }],
+    "tags": ["compiler", "lang-rust"]
+},
+{
+    "id": "compiler-incr",
+    "title": "compiler (incremental compilation)",
+    "description": "The Rust compiler",
+    "repository": "rust-lang/rust",
+    "labels": ["WG-compiler-incr"],
+    "links": [],
+    "tags": ["compiler", "lang-rust"]
+},
+{
+    "id": "compiler-const",
+    "title": "compiler (const generics and miri integration)",
+    "description": "The Rust compiler",
+    "repository": "rust-lang/rust",
+    "labels": ["WG-compiler-const"],
+    "links": [],
+    "tags": ["compiler", "lang-rust"]
+},
+{
+    "id": "compiler-nll",
+    "title": "compiler (borrow checker and non-lexical lifetimes [NLL])",
+    "description": "The Rust compiler",
+    "repository": "rust-lang/rust",
+    "labels": ["WG-compiler-nll"],
+    "links": [{
+      "text": "about",
+      "url": "https://paper.dropbox.com/doc/Non-Lexical-Lifetimes-u5uc6VxJic67K2ynmTiFV"
+    }],
+    "tags": ["compiler", "lang-rust"]
+},
+{
+    "id": "compiler-traits",
+    "title": "compiler (trait system)",
+    "description": "The Rust compiler",
+    "repository": "rust-lang/rust",
+    "labels": ["WG-compiler-traits"],
+    "links": [{
+      "text": "about",
+      "url": "https://paper.dropbox.com/doc/Trait-system-LCgNlSbM5cPOyEyWdoqzW"
+    }],
+    "tags": ["compiler", "lang-rust"]
 }
 ]

--- a/data/tab-category.json
+++ b/data/tab-category.json
@@ -55,9 +55,9 @@
     "link": null
 },
 {
-    "tab": "impl",
+    "tab": "starters",
     "category": "compiler",
-    "labels": ["B-RFC-approved", "C-tracking-issue"],
+    "labels": ["E-mentor"],
     "milestone": null,
     "link": null
 },

--- a/data/tab-category.json
+++ b/data/tab-category.json
@@ -186,5 +186,12 @@
     "labels": ["E-needs-mentor"],
     "milestone": null,
     "link": null
+},
+{
+    "tab": "mentor-others",
+    "category": "compiler",
+    "labels": ["E-needs-mentor"],
+    "milestone": null,
+    "link": null
 }
 ]

--- a/data/tab-category.json
+++ b/data/tab-category.json
@@ -193,5 +193,54 @@
     "labels": ["E-needs-mentor"],
     "milestone": null,
     "link": null
+},
+{
+    "tab": "impl",
+    "category": "compiler-errors",
+    "labels": ["E-mentor"],
+    "milestone": null,
+    "link": null
+},
+{
+    "tab": "impl",
+    "category": "compiler-front",
+    "labels": ["E-mentor"],
+    "milestone": null,
+    "link": null
+},
+{
+    "tab": "impl",
+    "category": "compiler-middle",
+    "labels": ["E-mentor"],
+    "milestone": null,
+    "link": null
+},
+{
+    "tab": "impl",
+   "category": "compiler-incr",
+   "labels": ["E-mentor"],
+   "milestone": null,
+   "link": null
+},
+{
+    "tab": "impl",
+    "category": "compiler-const",
+    "labels": ["E-mentor"],
+    "milestone": null,
+    "link": null
+},
+{
+    "tab": "impl",
+    "category": "compiler-nll",
+    "labels": ["E-mentor"],
+    "milestone": null,
+    "link": null
+},
+{
+    "tab": "impl",
+    "category": "compiler-traits",
+    "labels": ["E-mentor"],
+    "milestone": null,
+    "link": null
 }
 ]

--- a/data/tabs.json
+++ b/data/tabs.json
@@ -12,5 +12,10 @@
     "id": "blitz",
     "title": "libz blitz",
     "description": "The Libz Blitz is the library team’s major 2017 initiative: raising a solid core of the Rust crate ecosystem to a consistent level of completeness and quality"
+},
+{
+    "id": "mentor-others",
+    "title": "mentor others",
+    "description": "Write mentoring instructions to help get others started"
 }
 ]


### PR DESCRIPTION
I added a "Mentor Others" tab as well as setting up the compiler working groups. Here is a brief write-up:

https://gist.github.com/nikomatsakis/1aef48e9bba4a057f5791fbca20d72a6