### PR TITLE
added rust-cookbook to "starters" and "impl"

### DIFF
--- a/data/categories.json
+++ b/data/categories.json
@@ -70,6 +70,19 @@
     "links": [{ "text": "contributing", "url": "https://github.com/rust-lang/rust-by-example/blob/master/CONTRIBUTING.md" }],
     "tags": ["docs", "lang-rust"]
 },
+ {
+    "id": "rust-cookbook",
+    "title": "Rust Cookbook",
+    "description": "Work on bite-sized examples to get folks cooking with Rust",
+    "repository": "rust-lang-nursery/rust-cookbook",
+    "labels": [],
+    "links": [
+        {"text": "Contributing", "url": "https://github.com/rust-lang-nursery/rust-cookbook/blob/master/CONTRIBUTING.md"},
+        {"text": "Coordination and progress", "url": "https://paper.dropbox.com/doc/Rust-cookbook-DFaopl45jyZGWKI6iFDwD"},
+        {"text": "Gitter chat", "url": "https://gitter.im/rust-impl-period/WG-libs-cookbook"}
+    ],
+    "tags": ["docs", "libs"]
+},
 {
     "id": "compiler",
     "title": "compiler",

--- a/data/tab-category.json
+++ b/data/tab-category.json
@@ -62,6 +62,20 @@
     "link": null
 },
 {
+    "tab": "starters",
+    "category": "rust-cookbook",
+    "labels": ["easy"],
+    "milestone": null,
+    "link": null
+},
+{
+    "tab": "impl",
+    "category": "rust-cookbook",
+    "labels": ["example", "tracking issue"],
+    "milestone": null,
+    "link": null
+},
+{
     "tab": "impl",
     "category": "rls",
     "labels": [],


### PR DESCRIPTION
Hi,
I've added the rust-cookbook to "starters" and "impl".
The cookbook itself is nominally part of the libs-blitz but I did not want to spam all of the tabs. 
Any suggestions on how should we proceed with it?