### PR TITLE
filter cookbook "impl" issues by milestone instead of labels

### DIFF
--- a/data/tab-category.json
+++ b/data/tab-category.json
@@ -71,8 +71,8 @@
 {
     "tab": "impl",
     "category": "rust-cookbook",
-    "labels": ["example", "tracking issue"],
-    "milestone": null,
+    "labels": [],
+    "milestone": "impl period",
     "link": null
 },
 {


### PR DESCRIPTION
I want to display issues from two different categories. Unfortunately "labels" uses set intersection instead of sum, so I've decided to use milestone instead.