### PR TITLE
Declare body background color

### DIFF
--- a/static/work.css
+++ b/static/work.css
@@ -30,6 +30,7 @@ div.clear {
     clear: both;
 }
 body {
+    background-color: #fff;
     font-family: 'Fira Sans', "Helvetica Neue", Helvetica, Arial, sans-serif;
     margin-top: 20px;
     margin-bottom: 10px;


### PR DESCRIPTION
Not all users will have a default background color of white - granted, I'm sure only a tiny fraction. But since the content of the site doesn't account for this and can look from awkward to unreadable, a very simple solution is to declare the intended background color for the whole page directly.

Which I'm assuming here is white.

See: Firefox/about:config/browser.display.background_color