### PR TITLE
Fix overlap when the issue has no body

### DIFF
--- a/static/work.css
+++ b/static/work.css
@@ -181,7 +181,7 @@ div.shortCategory,
 div.tabAllIssues {
     margin-top: 1.2em;
     margin-bottom: 1.2em;
-    border-top: 0.25em solid #428bca;   
+    border-top: 0.25em solid #428bca;
 }
 div.tabAllIssues {
     padding-top: 0.6em;
@@ -190,13 +190,13 @@ div.tabCategory {
     margin-top: 1.2em;
     margin-bottom: 1.2em;
     padding-top: 0.6em;
-    border-top: 0.25em solid #428bca;   
+    border-top: 0.25em solid #428bca;
 }
 div.issue {
     margin-top: 0.6em;
     margin-bottom: 0.6em;
     padding-top: 1.2em;
-    border-top: 0.1em solid #428bca;   
+    border-top: 0.1em solid #428bca;
 }
 
 span.issueMore {
@@ -205,7 +205,6 @@ span.issueMore {
     text-decoration: underline;
     width: 2em;
     margin-top: -1em;
-    margin-bottom: 1.2em;
     cursor: pointer;
     color: #428bca;
 }
@@ -214,7 +213,7 @@ span.issueMore:hover {
 }
 
 div.issueLabels {
-    margin-top: -0.6em;
+    margin-top: 0.6em;
 }
 span.issueLabel {
     display: inline-block;


### PR DESCRIPTION
If the issue has no body (e.g. [rustfmt#1975](https://github.com/rust-lang-nursery/rustfmt/issues/1975)), the tags and title overlap:
<img width="783" alt="before" src="https://user-images.githubusercontent.com/7120871/31577327-5b18d22a-b104-11e7-81de-aae3a6acae78.png">

This PR just moves the margin from the `issueMore` tag to the `issueTag`:
<img width="786" alt="after" src="https://user-images.githubusercontent.com/7120871/31577337-8e297b4c-b104-11e7-9e3a-fd15fd564d9e.png">




