### PR TITLE
Make frontend easier to develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 /data/config.json
 /back/test-token.txt
 /front/node_modules
+/static/work.out.js*
 **/*.rs.bk

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ and after a timeout, the backend queries the GitHub API to get data about
 relevant issues. The backend then keeps this in memory and makes it available in
 a convenient JSON form on the `data` endpoint. The backend also serves static
 data - it will serve anything in the `static` directory verbatim, and any other
-URL it will serve `static/index.html` (configurable).
+URL it will serve `static/index.html` (configurable). Note that the `dev_mode`
+disables the caching of the assets, ideal when developing on the frontend.
 
 The backend is configurable via `data/config.json`.
 
@@ -69,7 +70,7 @@ cargo build
 
 ```
 cd front
-./node_modules/.bin/webpack --watch
+npm run dev:watch
 ```
 
 ## Testing

--- a/back/src/server.rs
+++ b/back/src/server.rs
@@ -75,7 +75,7 @@ struct WorkService {
 }
 
 impl WorkService {
-    fn route(req: &Request) -> Route {
+    fn route(&self, req: &Request) -> Route {
         if req.method() != &Method::Get {
             return Route::Unknown;
         }
@@ -83,6 +83,9 @@ impl WorkService {
             "/data/" => Route::Data,
             path if path.starts_with("/static/") => {
                 Route::Static(path["/static/".len()..].to_owned())
+            }
+            path if self.config.dev_mode && path.starts_with("/findwork/static/") => {
+                Route::Static(path["/findwork/static/".len()..].to_owned())
             }
             _ => Route::Index,
         }
@@ -129,7 +132,7 @@ impl Service for WorkService {
 
     fn call(&self, req: Request) -> Self::Future {
         let mut res = Response::new();
-        match WorkService::route(&req) {
+        match self.route(&req) {
             Route::Index => {
                 let path = PathBuf::from(&self.config.index_path);
                 let bytes = match self.load_file(&path) {

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -2871,14 +2871,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -2887,6 +2879,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -5116,15 +5116,6 @@
         "xtend": "4.0.1"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -5156,6 +5147,15 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/front/package.json
+++ b/front/package.json
@@ -1,9 +1,13 @@
 {
   "name": "front",
+  "private": true,
   "version": "1.0.0",
   "description": "A web app for finding Rust issues to work on.",
   "main": "webpack.config.js",
   "scripts": {
+    "prod": "webpack webpack.config.prod.js --progress",
+    "dev": "webpack --progress",
+    "dev:watch": "webpack --watch --progress",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",

--- a/front/src/index.js
+++ b/front/src/index.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
 import { Tabs } from './tabs';
 
-const API_URL = 'https://www.rustaceans.org/findwork/data/';
+const API_URL = process.env.FINDWORK_API;
 
 const App = (props) => {
   let body;

--- a/front/webpack.config.js
+++ b/front/webpack.config.js
@@ -1,9 +1,13 @@
+const webpack = require('webpack');
+
 module.exports = {
   entry: "./src/index.js",
   output: {
-    filename: "../static/work.out.js",
+    path: __dirname + '/../static',
+    filename: 'work.out.js',
     libraryTarget: 'var',
-    library: 'Work'
+    library: 'Work',
+    pathinfo: true
   },
   module: {
     loaders: [
@@ -17,5 +21,12 @@ module.exports = {
     contentBase: '.',
     historyApiFallback: true
   },
-  devtool: 'source-map'
+  devtool: 'source-map',
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env': {
+        'FINDWORK_API': JSON.stringify('/data/')
+      }
+    })
+  ]
 }

--- a/front/webpack.config.prod.js
+++ b/front/webpack.config.prod.js
@@ -4,7 +4,8 @@ const webpack = require('webpack');
 module.exports = {
   entry: "./src/index.js",
   output: {
-    filename: "../prod/work.out.js",
+    path: __dirname + '/../static',
+    filename: 'work.out.js',
     libraryTarget: 'var',
     library: 'Work'
   },
@@ -20,6 +21,7 @@ module.exports = {
     new UglifyJSPlugin(),
     new webpack.DefinePlugin({
       'process.env': {
+        'FINDWORK_API': JSON.stringify('https://www.rustaceans.org/findwork/data/'),
         'NODE_ENV': JSON.stringify('production')
       }
     })


### PR DESCRIPTION
Most static files are not adapted for development (prepended by `/findwork/`, the API URL is hardcoded...) or could benefit from Quality of Life changes.

List of changes:
 - Ignore compiled JS
 - Make package private (prevent publishing to NPM by mistake)
 - Add NPM scripts to ease compilation
 - Make API_URL variable so it can be switched for the development
server
 - Add a debug route to handle the production routes in index.html,
work.css… (prepended with `/findwork/`)