### PR TITLE
Only apply negative margin to labels if following issue body

### DIFF
--- a/front/src/tabs.js
+++ b/front/src/tabs.js
@@ -187,11 +187,13 @@ export class IssueList extends React.Component {
         for (const i in this.props.issues) {
             const issue = this.props.issues[i];
 
-            let body = issue.body.trim();
+            let bodyText = issue.body.trim();
+            let body = null;
             let bodyMore = null;
-            const linebreak = body.indexOf('\n');
+            const linebreak = bodyText.indexOf('\n');
             if (!this.state.expanded[i] && linebreak > 0) {
-                body = body.substring(0, linebreak);
+                bodyText = bodyText.substring(0, linebreak);
+
                 const showMore = () => {
                     this.setState(prevState => {
                         let expanded = prevState.expanded.slice();
@@ -201,8 +203,9 @@ export class IssueList extends React.Component {
                 };
                 bodyMore = <span className="issueMore" onClick={showMore}>...</span>;
             }
-
-            body = marked(body);
+            if (bodyText) {
+                body = <div className="issueBody" dangerouslySetInnerHTML={{__html: marked(bodyText)}} />
+            }
 
             let labels = [];
             for (const l of issue.labels) {
@@ -211,7 +214,7 @@ export class IssueList extends React.Component {
             issues.push(
                 <div className='issue' key={i}>
                     <a href={issue.html_url} target="_blank">{issue.title}</a>
-                    <div className="issueBody" dangerouslySetInnerHTML={{__html: body}} />
+                    {body}
                     {bodyMore}
                     <div className="issueLabels">{labels}</div>
                 </div>

--- a/static/work.css
+++ b/static/work.css
@@ -213,9 +213,11 @@ span.issueMore:hover {
     color: #2a6496;
 }
 
-div.issueLabels {
+div.issueBody + div.issueLabels,
+span.issueMore + div.issueLabels {
     margin-top: 0.6em;
 }
+
 span.issueLabel {
     display: inline-block;
     border: 1px solid black;


### PR DESCRIPTION
Should transform the current situation:
![2017-11-11-002322_773x271_scrot](https://user-images.githubusercontent.com/7784737/32687673-94fa4f78-c676-11e7-9ae9-e2120a560a1d.png)

into this new, more neat-o situation:
![2017-11-11-002309_780x296_scrot](https://user-images.githubusercontent.com/7784737/32687676-9d75fa12-c676-11e7-801b-50fdd52906ca.png)

`killercup` came up with the solution in #27, I'm just the grunt making a PR (zug zug).